### PR TITLE
Initial support for the Philomena API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 cache: yarn
 node_js:
-  - 8
   - 10
   - 12
   - 13

--- a/lib/Dinky.js
+++ b/lib/Dinky.js
@@ -3,7 +3,7 @@ const apply = require("./util/selfInvokingClass")
 const createLink = require("./util/link")
 const proxy = require("./util/proxy")
 
-const Lists = require("./Lists")
+// const Lists = require("./Lists")
 const Images = require("./Images")
 const Search = require("./Search")
 
@@ -30,7 +30,7 @@ class Dinky {
   }
 
   /**
-   * Creates a request handler for /images.json
+   * Creates a request handler for /api/v1/json/images
    *
    * @return {Images}
    *
@@ -41,7 +41,7 @@ class Dinky {
   }
 
   /**
-   * Creates a request handler for /search.json
+   * Creates a request handler for /api/v1/json/search/images
    *
    * @param {string | string[]} [tags = []] – a tag or a list of tags
    *
@@ -60,9 +60,12 @@ class Dinky {
    *
    * @return {Lists}
    */
-  lists() {
-    return new Lists({link: this.__link, dinky: this})
-  }
+  // TODO: the new API does not have an endpoint for lists
+  //       or at least it's not oublicly listed/documented
+
+  // lists() {
+  //   return new Lists({link: this.__link, dinky: this})
+  // }
 }
 
 module.exports = proxy({apply})(Dinky)

--- a/lib/Search.js
+++ b/lib/Search.js
@@ -16,7 +16,7 @@ class Search extends Request {
    * @param {string[] | string} [options.tags = []]
    */
   constructor({dinky, link, tags = []}) {
-    super({dinky, link, path: "search"})
+    super({dinky, link, path: "search/images"})
 
     if (tags.length > 0) {
       this.tags(...tags)
@@ -222,6 +222,7 @@ class Search extends Request {
    * @public
    */
   async random() {
+    // NB: random_image is not yet available as a query parameter in the new API
     this._query.set("random_image", true)
 
     const resolve = image => {

--- a/lib/util/link.js
+++ b/lib/util/link.js
@@ -60,7 +60,7 @@ function createLink(options = {}) {
       search.set("filter_id", params.filter)
     }
 
-    const pathname = `${path.join("/").replace(/\/{2,}/g, "/")}.json`
+    const pathname = `/api/v1/json/${path.join("/").replace(/\/{2,}/g, "/")}`
     const url = format({...base, pathname, search: search.toString()})
     const sendRequest = partial(fetch, url, {method: "get"})
 

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ Dinky implements chainable API to build each request and all requests will retur
 import dinky from "dinky.js"
 
 // The following request will return the 1th uploaded image from Derpibooru.
-// Equivalent to https://derpibooru.org/images/0.json request
+// Equivalent to https://derpibooru.org/api/v1/json/images/0 request
 dinky().images().id(0).then(console.log)
 ```
 
@@ -47,9 +47,10 @@ import dinky from "dinky.js"
 
 // You can specify tags right in the .search() method
 // The following example is equivalent of these requests:
-// https://derpibooru.org/search.json?q=artist:rainbow,safe&random_image=true
+// https://derpibooru.org/api/v1/json/search/images?q=artist:rainbow,safe
+// &random_image=true
 // ...and then this one:
-// https://derpibooru.org/images/<received image id>.json
+// https://derpibooru.org/api/v1/json/images/<received image id>
 dinky().search(["artist:rainbow", "safe"]).random()
   .then(console.log)
 ```
@@ -132,11 +133,11 @@ Creates a new instance of the Derpibooru API client
 
 ##### `images() -> {Images}`
 
-Creates a request handler for `/images.json`
+Creates a request handler for `/api/v1/json/images`
 
 ##### `search([tags]) -> {Search}`
 
-Creates a request handler for `/search.json`. This method takes a list of tags
+Creates a request handler for `/api/v1/json/search/images`. This method takes a list of tags
 
   - **{string | string[]}** [tags = []] – a tag or a list of tags and returns Search instance
 
@@ -144,7 +145,7 @@ Creates a request handler for `/search.json`. This method takes a list of tags
 
 ##### `constructor() -> {Images}`
 
-Creates a request handler for `/images.json`
+Creates a request handler for `/api/v1/json/images`
 
 #### Instance methods
 
@@ -156,7 +157,7 @@ Returns an image with given ID
 
 ##### `constructor() -> {Search}`
 
-Creates a request handler for `/search.json`.
+Creates a request handler for `/api/v1/json/search/images`.
 
 #### Instance methods
 
@@ -232,7 +233,7 @@ Sets the **maximal** score of requested images
 
 If been called, the API will return random image
 
-### `class Lists > Request`
+### `class Lists > Request (currently unavailable)`
 
 ##### `constructor() -> {Lists}`
 

--- a/test/unit/Dinky.js
+++ b/test/unit/Dinky.js
@@ -4,13 +4,14 @@ const pq = require("proxyquire")
 const {spy} = require("sinon")
 
 const dinky = require("../../lib/Dinky")
-const Lists = require("../../lib/Lists")
+// const Lists = require("../../lib/Lists")
 const Images = require("../../lib/Images")
 const Search = require("../../lib/Search")
 
-test(".lists() returns the Lists instance", t => {
-  t.true(dinky().lists() instanceof Lists)
-})
+// TODO: see lib/Dinky.js:63
+// test(".lists() returns the Lists instance", t => {
+//   t.true(dinky().lists() instanceof Lists)
+// })
 
 test(".images() returns the Images instance", t => {
   t.true(dinky().images() instanceof Images)

--- a/test/unit/Images.js
+++ b/test/unit/Images.js
@@ -6,7 +6,7 @@ const createNoopLink = require("../helper/createNoopLink")
 
 test.beforeEach(createNoopLink)
 
-test("Creates a link with path to /images.json", async t => {
+test("Creates a link with path to /api/v1/json/images", async t => {
   const link = t.context.noopLink
 
   await new Images({link})

--- a/test/unit/Search.js
+++ b/test/unit/Search.js
@@ -9,14 +9,14 @@ const Search = require("../../lib/Search")
 
 test.beforeEach(createNoopLink)
 
-test("Creates a link with path to /search.json", async t => {
+test("Creates a link with path to /api/v1/json/search/images", async t => {
   const link = t.context.noopLink
 
   await new Search({link})
 
   const [path] = link.firstCall.args
 
-  t.deepEqual(path, ["search"])
+  t.deepEqual(path, ["search/images"])
 })
 
 test("Creates search request without tags by default", async t => {

--- a/test/unit/util/link.js
+++ b/test/unit/util/link.js
@@ -36,13 +36,13 @@ test("Creates a correct request address from given path and query", async t => {
 
   query.set("q", "princess luna")
 
-  await link(["search"], query)
+  await link(["search", "images"], query)
 
   t.true(fetch.called())
 
   const actual = parse(fetch.lastUrl())
 
-  t.is(actual.pathname, "/search.json")
+  t.is(actual.pathname, "/api/v1/json/search/images")
   t.is(actual.query, "q=princess+luna")
 })
 
@@ -162,5 +162,5 @@ test("Throws an error for non 2xx response", async t => {
   t.true(err.response instanceof Response)
   t.is(err.status, 404)
   t.is(err.statusText, "Not Found")
-  t.is(err.url, "https://derpibooru.org/search.json")
+  t.is(err.url, "https://derpibooru.org/api/v1/json/search")
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,10 +1253,10 @@ commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
-commander@~2.17.1:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
-  integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
+commander@~2.20.3:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 common-path-prefix@^1.0.0:
   version "1.0.0"
@@ -2255,9 +2255,9 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 handlebars@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
-  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -4729,11 +4729,11 @@ typedarray-to-buffer@^3.1.5:
     is-typedarray "^1.0.0"
 
 uglify-js@^3.1.4:
-  version "3.4.9"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
-  integrity sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.3.tgz#f918fce9182f466d5140f24bb0ff35c2d32dcc6a"
+  integrity sha512-7tINm46/3puUA4hCkKYo4Xdts+JDaVC9ZPRcG8Xw9R4nhO/gZgUM3TENq8IF4Vatk8qCig4MzP/c8G4u2BkVQg==
   dependencies:
-    commander "~2.17.1"
+    commander "~2.20.3"
     source-map "~0.6.1"
 
 uid2@0.0.3:


### PR DESCRIPTION
Derpibooru was rewritten from the ground up a few months ago and while some of the old API endpoints are still available, they will soon become deprecated and unavailable. See this forum post: https://derpibooru.org/forums/meta/topics/old-api-deprecation-notice

The docs for the new Philomena API are available here: https://derpibooru.org/pages/api

This pull request changes the way the Link class works, so that it will fetch `/api/v1/json/:endpoint` instead of `/:endpoint.json`. It also changes the link for the Search class from "search" to "search/images" (Derpi's search API has a lot of other endpoints to work with now, you might want to implement them as separate methods, if you want). For the most important part, everything works, however there are a few things that do not currently work (and aren't really the module's fault):

 - There are no endpoints for Lists anymore. Maybe they've recently removed them completely?
 - The Search API no longer accepts `random_image` as a query parameter, thus the `.random()` method will always return undefined.