### PR TITLE
Fix type declarations that prevent TypeScript builds from succeeding

### DIFF
--- a/lib/Dinky.d.ts
+++ b/lib/Dinky.d.ts
@@ -44,7 +44,7 @@ interface DinkyRequestOptions {
   filter?: number
 }
 
-class Dinky {
+declare class Dinky {
   /**
    * Creates an instance of derpibooru API client.
    * See `DinkyRequestOptions` for more details on configuration.
@@ -88,9 +88,9 @@ class Dinky {
  *
  * Default options: `{}`
  */
-function dinky(options?: DinkyRequestOptions): Dinky
+declare function dinky(options?: DinkyRequestOptions): Dinky
 
-class NetworkError extends Error {
+declare class NetworkError extends Error {
   response: Response
   url: string
   status: number
@@ -280,7 +280,7 @@ interface ImagesSearch extends Search<responses.ImagesResponse> {
  * properties naming, in TypeScript `camelCase` is more conventional, so these are
  * transformed to `camelCase` in `dinky.js`
  */
-namespace responses {
+declare namespace responses {
   // There are no strict schema declarations, the types
   // are manually written using https://derpibooru.org/pages/api
 


### PR DESCRIPTION
TypeScript builds fail with the following error:
```
node_modules/dinky.js/lib/Dinky.d.ts:47:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

47 class Dinky {
   ~~~~~


Found 1 error.
```
when using the following tsconfig:

```json
{
  "compilerOptions": {
    "declaration": true,
    "esModuleInterop": true,
    "forceConsistentCasingInFileNames": true,
    "importHelpers": true,
    "module": "commonjs",
    "outDir": "./dist",
    "rootDirs": [
      "./src"
    ],
    "strict": true,
    "target": "es2017",
    "typeRoots": [
      "./node_modules/@types"
    ]
  },
  "exclude": [
    "node_modules",
    "./config.json"
  ],
  "include": [
    "./src/**/*.ts"
  ]
}
```

I haven't tested with other configurations, but I feel like the reason it fails is that I have `strict` and/or `declaration` set to `true`.

As noted in https://github.com/octet-stream/dinky/issues/11#issuecomment-701648613, the `declare` modifier is missing from the following types:

- `class Dinky`
- `function dinky`
- `class NetworkError`
- `namespace responses`

With these changes in place, the builds are successful and the type annotations/completions also work correctly (so the in-editor behavior hasn't changed).